### PR TITLE
[FEAT] B_ARTICLE_01 - 게시글 목록 API 구현

### DIFF
--- a/socialFeed/src/main/java/backend/socialFeed/article/controller/ArticleController.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/controller/ArticleController.java
@@ -1,14 +1,21 @@
 package backend.socialFeed.article.controller;
 
+import backend.socialFeed.article.ArticleType;
 import backend.socialFeed.article.dto.ArticleResponseDto;
 import backend.socialFeed.article.entity.Article;
 import backend.socialFeed.article.service.ArticleService;
 import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.misc.IntSet;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,4 +44,30 @@ public class ArticleController {
         // DTO 반환
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
+
+
+    @GetMapping("/api/article/")
+    public List<Article> getArticles(
+            @RequestParam(required = false) String hashtag,
+            @RequestParam(required = false) ArticleType type,
+            @RequestParam(defaultValue = "createdAt") String orderBy,
+            @RequestParam(defaultValue = "ASC") String orderDirection,
+            @RequestParam(defaultValue = "title,content") String searchBy,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "10") int pageCount,
+            @RequestParam(defaultValue = "0") int page) {
+        Page<Article> articlesPage = articleService.getArticles(
+                hashtag, type, orderBy, orderDirection, searchBy, search, pageCount, page
+        );
+
+        return articlesPage.stream()
+                .map(article -> {
+                    // 최대 20자만 포함
+                    article.setContent(article.getContent().substring(0, Math.min(article.getContent().length(), 20)));
+                    return article;
+                })
+                .collect(Collectors.toList());
+    }
+    
+
 }

--- a/socialFeed/src/main/java/backend/socialFeed/article/entity/Article.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/entity/Article.java
@@ -1,14 +1,10 @@
 package backend.socialFeed.article.entity;
 
 import backend.socialFeed.article.ArticleType;
+import backend.socialFeed.hashtags.entity.Hashtags;
 import backend.socialFeed.user.model.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,10 +14,12 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class Article {
@@ -58,7 +56,12 @@ public class Article {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @JsonManagedReference
+    @OneToMany(mappedBy = "article")
+    private List<Hashtags> hashtags;
+
     public void updateShareCount() {
         this.shareCount += 1;
     }
+
 }

--- a/socialFeed/src/main/java/backend/socialFeed/article/repository/ArticleRepository.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/repository/ArticleRepository.java
@@ -1,7 +1,25 @@
 package backend.socialFeed.article.repository;
 
+import backend.socialFeed.article.ArticleType;
 import backend.socialFeed.article.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, String> {
+
+    @Query("SELECT a FROM Article a LEFT JOIN a.hashtags h " +
+            "WHERE (:hashtag IS NULL OR h.name = :hashtag) " +
+            "AND (:type IS NULL OR a.type = :type) " +
+            "AND ((:searchBy = 'title' AND a.title LIKE %:search%) " +
+            "OR (:searchBy = 'content' AND a.content LIKE %:search%) " +
+            "OR (:searchBy = 'title,content' AND (a.title LIKE %:search% OR a.content LIKE %:search%)))")
+    Page<Article> searchArticles(@Param("hashtag") String hashtag,
+                                 @Param("type") ArticleType type,
+                                 @Param("searchBy") String searchBy,
+                                 @Param("search") String search,
+                                 Pageable pageable);
+
 }

--- a/socialFeed/src/main/java/backend/socialFeed/article/respotiory/ArticleRepository.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/respotiory/ArticleRepository.java
@@ -1,9 +1,0 @@
-package backend.socialFeed.article.respotiory;
-
-import backend.socialFeed.article.entity.Article;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ArticleRepository extends JpaRepository<Article, String> {
-}

--- a/socialFeed/src/main/java/backend/socialFeed/article/service/ArticleService.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/service/ArticleService.java
@@ -1,8 +1,13 @@
 package backend.socialFeed.article.service;
 
+import backend.socialFeed.article.ArticleType;
 import backend.socialFeed.article.entity.Article;
-import backend.socialFeed.article.respotiory.ArticleRepository;
+import backend.socialFeed.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,5 +24,11 @@ public class ArticleService {
         article.setViewCount(article.getViewCount() + 1);
 
         return articleRepository.save(article);
+    }
+
+    public Page<Article> getArticles(String hashtag, ArticleType type, String orderBy, String orderDirection, String searchBy, String search, int pageCount, int page) {
+        Sort sort = Sort.by(Sort.Direction.fromString(orderDirection), orderBy);
+        Pageable pageable = PageRequest.of(page, pageCount, sort);
+        return articleRepository.searchArticles(hashtag, type, searchBy, search, pageable);
     }
 }

--- a/socialFeed/src/main/java/backend/socialFeed/hashtags/entity/Hashtags.java
+++ b/socialFeed/src/main/java/backend/socialFeed/hashtags/entity/Hashtags.java
@@ -1,6 +1,7 @@
 package backend.socialFeed.hashtags.entity;
 
 import backend.socialFeed.article.entity.Article;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -26,6 +27,7 @@ public class Hashtags {
     @Column(nullable = false)
     private String name;
 
+    @JsonBackReference
     @ManyToOne
     private Article article;
 }


### PR DESCRIPTION
## 작업 내용
> 이번 PR에 포함될 작업 내용에 대한 간략한 설명
게시물 목록 조회 API 구현
(hashtag, type, order, search, page count 구현)


## 참고(선택)
> 리뷰어가 참고할만한 내용
- [ ] (로그인 가정) hashtag 검색어 미입력 시 본인계정 id를 default 값으로 사용하는 기능 - 주말 내 추가 예정

✅ merge 된 master를 pull 받아 작업했는데, article repository가 중복으로 생성되어 있어서 하나 삭제 후 작업 진행했습니다.

### #️⃣이슈 번호
> 연결된 이슈 번호 (#번호)
#13 


