### PR TITLE
[TEST] T_STATISTIC_01 통계 기능 테스트, 연관관계 편의 메소드 작성 

### DIFF
--- a/socialFeed/src/main/java/backend/socialFeed/article/entity/Article.java
+++ b/socialFeed/src/main/java/backend/socialFeed/article/entity/Article.java
@@ -5,15 +5,12 @@ import backend.socialFeed.hashtags.entity.Hashtags;
 import backend.socialFeed.user.model.User;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
@@ -57,11 +54,15 @@ public class Article {
     private LocalDateTime updatedAt;
 
     @JsonManagedReference
-    @OneToMany(mappedBy = "article")
-    private List<Hashtags> hashtags;
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    private List<Hashtags> hashtags = new ArrayList<>();
 
     public void updateShareCount() {
         this.shareCount += 1;
     }
 
+    public void addHashtag(Hashtags hashtag) {
+        hashtags.add(hashtag);
+        hashtag.setArticle(this);
+    }
 }

--- a/socialFeed/src/main/java/backend/socialFeed/hashtags/entity/Hashtags.java
+++ b/socialFeed/src/main/java/backend/socialFeed/hashtags/entity/Hashtags.java
@@ -8,17 +8,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
+@ToString(of = {"id", "name"})
 public class Hashtags {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +27,8 @@ public class Hashtags {
     @JsonBackReference
     @ManyToOne
     private Article article;
+
+    public void setArticle(Article article) {
+        this.article = article;
+    }
 }

--- a/socialFeed/src/main/java/backend/socialFeed/statistic/dto/StatisticRequest.java
+++ b/socialFeed/src/main/java/backend/socialFeed/statistic/dto/StatisticRequest.java
@@ -55,15 +55,16 @@ public class StatisticRequest {
         StatisticValue finalValue = StatisticValue.from(value);
 
         // 통계 시작일, 종료일 유효성 검사
+        // 2024-08-26, 2024-08-27이 제공될 때, 1을 반환
         long daysBetween = ChronoUnit.DAYS.between(finalStart, finalEnd);
 
         if(daysBetween < 0) {
             // 시작일이 종료일보다 미래
             throw new IllegalArgumentException(START_AFTER_END);
-        } else if(finalType == StatisticType.DATE && daysBetween > 30) {
+        } else if(finalType == StatisticType.DATE && daysBetween >= 30) {
             // 일별 통계 시 30일 초과 불가
             throw new IllegalArgumentException(TOO_LONG_DATE_QUERY);
-        } else if(finalType == StatisticType.HOUR && daysBetween > 7) {
+        } else if(finalType == StatisticType.HOUR && daysBetween >= 7) {
             // 시간별 통계 시 7일 초과 불가
             throw new IllegalArgumentException(TOO_LONG_HOUR_QUERY);
         }

--- a/socialFeed/src/main/java/backend/socialFeed/statistic/dto/StatisticResponse.java
+++ b/socialFeed/src/main/java/backend/socialFeed/statistic/dto/StatisticResponse.java
@@ -1,11 +1,13 @@
 package backend.socialFeed.statistic.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 @Getter
+@EqualsAndHashCode
 public class StatisticResponse {
     private String date; // 일별/시간대별 통계 결과를 위해 String으로 포맷
     private Integer count;

--- a/socialFeed/src/test/java/backend/socialFeed/statistic/controller/StatisticControllerTest.java
+++ b/socialFeed/src/test/java/backend/socialFeed/statistic/controller/StatisticControllerTest.java
@@ -1,0 +1,133 @@
+package backend.socialFeed.statistic.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import backend.socialFeed.statistic.dto.StatisticRequest;
+import backend.socialFeed.statistic.dto.StatisticResponse;
+import backend.socialFeed.statistic.service.StatisticService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = StatisticController.class)
+public class StatisticControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StatisticService statisticService;
+
+    private List<StatisticResponse> mockResponses;
+
+    @BeforeEach
+    public void setUp() {
+        mockResponses = Arrays.asList(
+                new StatisticResponse("2024-08-21", 5),
+                new StatisticResponse("2024-08-22", 10)
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("통계: 정상 동작 시나리오 - 모든 파라미터 다 들어온 경우")
+    public void getStatistic_WhenValid_ShouldReturnStatisticResponses() throws Exception {
+        // Given
+        Mockito.when(statisticService.getStatistics(any(StatisticRequest.class))).thenReturn(mockResponses);
+
+        // When & Then
+        mockMvc.perform(get("/statistics")
+                        .param("type", "date")
+                        .param("start", "2024-08-21T00:00:00")
+                        .param("end", "2024-08-23T00:00:00")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].date").value("2024-08-21"))
+                .andExpect(jsonPath("$[0].count").value(5))
+                .andExpect(jsonPath("$[1].date").value("2024-08-22"))
+                .andExpect(jsonPath("$[1].count").value(10));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("통계: 정상 동작 시나리오 - default value 로직 검증")
+    public void getStatistic_WhenDefaultValueLoginWorking_ShouldReturnStatisticResponses() throws Exception {
+        // Given
+        Mockito.when(statisticService.getStatistics(any(StatisticRequest.class)))
+                .thenReturn(mockResponses);
+
+        // When & Then
+        mockMvc.perform(get("/statistics")
+                        // Required 값 제외하고 모두 null으로 요청
+                        .param("type", "date")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].date").value("2024-08-21"))
+                .andExpect(jsonPath("$[0].count").value(5))
+                .andExpect(jsonPath("$[1].date").value("2024-08-22"))
+                .andExpect(jsonPath("$[1].count").value(10));
+    }
+
+    static Stream<Arguments> provideInvalidParameter() {
+        return Stream.of(
+                Arguments.of("type", "datee"), // type이 date, hour 중 하나가 아님
+                Arguments.of("value", "countt") // value가 count, like_count, view_count, share_count 중 하나가 아님
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidParameter")
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("통계: 유효하지 않은 파라미터 - type, value invalid")
+    public void getStatistic_WhenParameterIsInvalid_ShouldThrowIllegalArgumentExceptionWithBadRequest(String name, String value) throws Exception {
+        // When & Then
+        mockMvc.perform(get("/statistics")
+                        .param(name, value)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    static Stream<Arguments> provideInvalidDateRange() {
+        return Stream.of(
+                // start가 end보다 미래
+                Arguments.of("date", "2024-08-23T00:00:00", "2024-08-21T00:00:00"),
+                // 일별 통계인데 30일 초과
+                Arguments.of("date", "2024-08-01T00:00:00", "2024-08-31T00:00:00"),
+                // 시간별 통계인데 7일 초과
+                Arguments.of("hour", "2024-08-01T00:00:00", "2024-08-08T00:00:00")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidDateRange")
+    @WithMockUser(username = "testuser@example.com")
+    @DisplayName("날짜 유효성 검사 실패")
+    public void getStatistic_WhenDateRangeIsInvalid_ShouldThrowIllegalArgumentExceptionWithBadRequest(String type, String start, String end) throws Exception {
+        // When & Then
+        mockMvc.perform(get("/statistics")
+                        .param("type", type)
+                        .param("start", start)
+                        .param("end", end)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/socialFeed/src/test/java/backend/socialFeed/statistic/repository/ArticleQueryRepositoryTest.java
+++ b/socialFeed/src/test/java/backend/socialFeed/statistic/repository/ArticleQueryRepositoryTest.java
@@ -1,0 +1,75 @@
+package backend.socialFeed.statistic.repository;
+
+import backend.socialFeed.article.entity.Article;
+import backend.socialFeed.article.repository.ArticleRepository;
+import backend.socialFeed.common.config.QueryDslConfig;
+import backend.socialFeed.hashtags.entity.Hashtags;
+import backend.socialFeed.statistic.dto.StatisticRequest;
+import backend.socialFeed.statistic.dto.StatisticResponse;
+import backend.socialFeed.user.model.User;
+import backend.socialFeed.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class, ArticleQueryRepository.class})
+@DisplayName("통계 Repository 테스트")
+class ArticleQueryRepositoryTest {
+    @Autowired
+    private ArticleQueryRepository articleQueryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @BeforeEach
+    public void setUp() {
+        // 기준일
+        User user = userRepository.save(User.builder().email("email").verified(true).build());
+
+        for (int i = 0; i < 10; i++) {
+            Hashtags hashtag = Hashtags.builder().name("stringbuckwheat test").build();
+
+            Article a = Article.builder()
+                    .id(UUID.randomUUID().toString())
+                    .content("content " + i)
+                    .title("HOUR article " + i)
+                    .likeCount(i)
+                    .shareCount(i * 2)
+                    .viewCount(i * 3)
+                    .hashtags(new ArrayList<>())
+                    .user(user)
+                    .build();
+
+            a.addHashtag(hashtag);
+
+            articleRepository.save(a);
+        }
+    }
+
+
+    @ParameterizedTest
+    @DisplayName("Type, Value 경우의 수에 따른 테스트 시나리오 테스트")
+    @ArgumentsSource(StatisticRequestProvider.class)
+    public void getStatistics(StatisticRequest request, int listSize, int count) {
+        List<StatisticResponse> result = articleQueryRepository.getStatistics(request);
+
+        assertEquals(listSize, result.size());
+        assertEquals(count, result.get(0).getCount());
+    }
+}

--- a/socialFeed/src/test/java/backend/socialFeed/statistic/repository/StatisticRequestProvider.java
+++ b/socialFeed/src/test/java/backend/socialFeed/statistic/repository/StatisticRequestProvider.java
@@ -1,0 +1,134 @@
+package backend.socialFeed.statistic.repository;
+
+import backend.socialFeed.statistic.dto.StatisticRequest;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class StatisticRequestProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        int likeCount = 0;
+
+        for (int i = 0; i < 10; i++) {
+            likeCount += i;
+        }
+
+        int shareCount = 2 * likeCount;
+        int viewCount = 3 * likeCount;
+
+        String hashtag = "stringbuckwheat test";
+
+        LocalDateTime start = LocalDateTime.now().minusDays(1);
+
+        return Stream.of(
+                // 1. HOUR / COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "hour",
+                                start,
+                                start.plusDays(2),
+                                "count",
+                                "testUsername"),
+                        1,
+                        10
+                ),
+                // 2. HOUR / VIEW_COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "hour",
+                                start,
+                                start.plusDays(2),
+                                "view_count",
+                                "testUsername"),
+                        1,
+                        viewCount
+                ),
+
+                // 3. HOUR / LIKE COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "hour",
+                                start,
+                                start.plusDays(2),
+                                "like_count",
+                                "testUsername"),
+                        1,
+                        likeCount
+                ),
+
+                // 4. HOUR / SHARE_COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "hour",
+                                start,
+                                start.plusDays(2),
+                                "share_count",
+                                "testUsername"),
+                        1,
+                        shareCount
+                ),
+
+                //////////////////////// DATE
+                // 5. DATE / COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "date",
+                                start,
+                                start.plusDays(2),
+                                "count",
+                                "testUsername"),
+                        1,
+                        10
+                ),
+                // 6. DATE / VIEW_COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "date",
+                                start,
+                                start.plusDays(2),
+                                "view_count",
+                                "testUsername"),
+                        1,
+                        viewCount
+                ),
+
+                // 7. DATE / LIKE_COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "date",
+                                start,
+                                start.plusDays(2),
+                                "like_count",
+                                "testUsername"),
+                        1,
+                        likeCount
+                ),
+
+                // 8. DATE / SHARE_COUNT
+                Arguments.of(
+                        StatisticRequest.createWithDefaults(
+                                hashtag,
+                                "date",
+                                start,
+                                start.plusDays(2),
+                                "share_count",
+                                "testUsername"),
+                        1,
+                        shareCount
+                )
+        );
+    }
+}

--- a/socialFeed/src/test/java/backend/socialFeed/statistic/service/StatisticServiceImplTest.java
+++ b/socialFeed/src/test/java/backend/socialFeed/statistic/service/StatisticServiceImplTest.java
@@ -1,0 +1,91 @@
+package backend.socialFeed.statistic.service;
+
+import backend.socialFeed.statistic.dto.StatisticRequest;
+import backend.socialFeed.statistic.dto.StatisticResponse;
+import backend.socialFeed.statistic.repository.ArticleQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("통계 컨트롤러 테스트")
+public class StatisticServiceImplTest {
+
+    @Mock
+    private ArticleQueryRepository articleQueryRepository;
+
+    @InjectMocks
+    private StatisticServiceImpl statisticService;
+
+    @Test
+    @DisplayName("일별 조회 시, 통계 결과가 없는 날 count 0")
+    public void getStatistic_WhenDate_ShouldReturnStatisticResponseWithDefaultZero() {
+        // Given
+        LocalDateTime start = LocalDateTime.of(2024, 8, 21, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 8, 23, 0, 0);
+        StatisticRequest request = StatisticRequest.createWithDefaults(
+                "hashtag", "date", start, end, "count", "username"
+        );
+
+        List<StatisticResponse> mockResponses = Arrays.asList(
+                new StatisticResponse("2024-08-21", 5),
+                new StatisticResponse("2024-08-22", 10)
+        );
+
+        when(articleQueryRepository.getStatistics(request)).thenReturn(mockResponses);
+
+        // When
+        List<StatisticResponse> result = statisticService.getStatistics(request);
+
+        // Then
+        // 통계 결과가 없는 날짜에 0이 들어가는지 확인
+        List<StatisticResponse> expected = Arrays.asList(
+                new StatisticResponse("2024-08-21", 5),
+                new StatisticResponse("2024-08-22", 10),
+                new StatisticResponse("2024-08-23", 0)
+        );
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    @DisplayName("시간대별 조회 시, 통계 결과가 없는 시간 count 0")
+    public void getStatistic_WhenHour_ShouldReturnStatisticResponseWithDefaultZero() {
+        // Given
+        LocalDateTime start = LocalDateTime.of(2024, 8, 21, 18, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 8, 21, 20, 0);
+        StatisticRequest request = StatisticRequest.createWithDefaults(
+                "hashtag", "hour", start, end, "count", "username"
+        );
+
+        List<StatisticResponse> mockResponses = Arrays.asList(
+                new StatisticResponse("2024-08-21 18:00", 3),
+                new StatisticResponse("2024-08-21 19:00", 7)
+        );
+
+        when(articleQueryRepository.getStatistics(request)).thenReturn(mockResponses);
+
+        // When
+        List<StatisticResponse> result = statisticService.getStatistics(request);
+
+        // Then
+        // 통계 결과가 없는 날짜/시간에 0이 들어가는지 확인
+        List<StatisticResponse> expected = Arrays.asList(
+                new StatisticResponse("2024-08-21 18:00", 3),
+                new StatisticResponse("2024-08-21 19:00", 7),
+                new StatisticResponse("2024-08-21 20:00", 0)
+        );
+
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## 작업 내용
> 테스트 데이터 저장 편의성을 위해 Article-Hashtag 간 연관관계 편의 메소드 생성
> (Article-Hashtag 간 CascadeType.ALL을 설정하여 **Article 저장 시 Hashtag도 함께 저장**될 수 있도록 구현)
>
> 통계 요청 유효성 검사 로직 수정 및 테스트 편의성을 위해 EqualsAndHashCode 어노테이션 추가
>
> 레이어 별 테스트 코드 구현


### #️⃣이슈 번호
#38 

